### PR TITLE
bug: C/CE button functions swapped

### DIFF
--- a/PyCalc Pro V.1.5/Src/PyCalc_Pro_V1.5.py
+++ b/PyCalc Pro V.1.5/Src/PyCalc_Pro_V1.5.py
@@ -524,9 +524,9 @@ def main_GUI_Function():
         if text == "=":
             input_var.set(evaluate_expression(input_var.get()))
         elif text == "CE":
-            input_var.set("")
-        elif text == "C":
             input_var.set(input_var.get()[:-1])
+        elif text == "C":
+            input_var.set("")
         elif text == "Credit":
             open_credit_window()
         elif text == "Unit Converter":


### PR DESCRIPTION
- Closes #13
- Swaps the functionality of `C` and `CE`

*Tests*

- Enter 1+1.  Press enter.  Press `C` and it should clear the display.
- WOrth noting I cant find any calculator with a `CE` button to see how it works.  I dont know that `CE` actually works correctly either.